### PR TITLE
Add try-catch in GetResult loop

### DIFF
--- a/UnifiedApi/Client/Services/Submitter/Service.cs
+++ b/UnifiedApi/Client/Services/Submitter/Service.cs
@@ -435,17 +435,22 @@ public class Service : AbstractClientService
                               taskStatus,
                               ex) =>
                              {
-                               var statusCode = StatusCodesLookUp.Keys.Contains(taskStatus)
-                                                  ? StatusCodesLookUp[taskStatus]
-                                                  : ArmonikStatusCode.Unknown;
+                               try
+                               {
+                                 var statusCode = StatusCodesLookUp.Keys.Contains(taskStatus)
+                                                    ? StatusCodesLookUp[taskStatus]
+                                                    : ArmonikStatusCode.Unknown;
 
-                               ResultHandlerDictionary[taskId]
-                                 .HandleError(new ServiceInvocationException(ex,
-                                                                             statusCode),
-                                              taskId);
-
-                               ResultHandlerDictionary.TryRemove(taskId,
-                                                                 out _);
+                                 ResultHandlerDictionary[taskId]
+                                   .HandleError(new ServiceInvocationException(ex,
+                                                                               statusCode),
+                                                taskId);
+                               }
+                               finally
+                               {
+                                 ResultHandlerDictionary.TryRemove(taskId,
+                                                                   out _);
+                               }
                              });
         }
         else

--- a/UnifiedApi/Client/Services/Submitter/Service.cs
+++ b/UnifiedApi/Client/Services/Submitter/Service.cs
@@ -35,6 +35,8 @@ using ArmoniK.DevelopmentKit.Client.Services.Common;
 using ArmoniK.DevelopmentKit.Common;
 using ArmoniK.DevelopmentKit.Common.Exceptions;
 
+using Google.Protobuf.WellKnownTypes;
+
 using JetBrains.Annotations;
 
 using Microsoft.Extensions.Logging;
@@ -280,8 +282,7 @@ public class Service : AbstractClientService
                           20000,
                           30000,
                         };
-    var       idx = 0;
-    using var _   = Logger?.BeginPropertyScope(("Function", "ActiveGetResults"));
+    var idx = 0;
 
     while (missing.Count != 0)
     {
@@ -294,7 +295,7 @@ public class Service : AbstractClientService
         {
           try
           {
-            Logger?.LogTrace("responseHandler for {taskId}",
+            Logger?.LogTrace("Response handler for {taskId}",
                              resultStatusData.TaskId);
             responseHandler(resultStatusData.TaskId,
                             SessionService.TryGetResultAsync(new ResultRequest
@@ -308,7 +309,7 @@ public class Service : AbstractClientService
           catch (Exception e)
           {
             Logger?.LogWarning(e,
-                               "resultHandler for {taskId} threw an error",
+                               "Response handler for {taskId} threw an error",
                                resultStatusData.TaskId);
             try
             {
@@ -326,6 +327,7 @@ public class Service : AbstractClientService
         }
 
         missing.ExceptWith(resultStatusCollection.IdsReady.Select(x => x.TaskId));
+        var x = Duration.FromTimeSpan(TimeSpan.FromMinutes(5));
 
         foreach (var resultStatusData in resultStatusCollection.IdsResultError)
         {
@@ -347,7 +349,7 @@ public class Service : AbstractClientService
               break;
           }
 
-          Logger?.LogDebug("errorHandler for {taskId}, {taskStatus}: {details}",
+          Logger?.LogDebug("Error handler for {taskId}, {taskStatus}: {details}",
                            resultStatusData.TaskId,
                            taskStatus,
                            details);

--- a/UnifiedApi/Client/Services/Submitter/Service.cs
+++ b/UnifiedApi/Client/Services/Submitter/Service.cs
@@ -293,6 +293,8 @@ public class Service : AbstractClientService
         {
           try
           {
+            Logger?.LogTrace("responseHandler for {taskId}",
+                             resultStatusData.TaskId);
             responseHandler(resultStatusData.TaskId,
                             SessionService.TryGetResultAsync(new ResultRequest
                                                              {
@@ -304,9 +306,9 @@ public class Service : AbstractClientService
           }
           catch (Exception e)
           {
-            Logger.LogWarning("resultHandler for {taskId} threw an error: {e}",
-                              resultStatusData.TaskId,
-                              e);
+            Logger?.LogWarning(e,
+                              "resultHandler for {taskId} threw an error",
+                              resultStatusData.TaskId);
             try
             {
               errorHandler(resultStatusData.TaskId,
@@ -315,8 +317,8 @@ public class Service : AbstractClientService
             }
             catch (Exception e2)
             {
-              Logger.LogError("An error occured while handling another error.\n{e2}\n{e}",
-                              e2,
+              Logger?.LogError(e2,
+                              "An error occured while handling another error: {details}",
                               e);
             }
           }
@@ -344,16 +346,21 @@ public class Service : AbstractClientService
               break;
           }
 
+          Logger?.LogDebug("errorHandler for {taskId}, {taskStatus}: {details}",
+                           resultStatusData.TaskId,
+                           taskStatus,
+                           details);
           try
           {
             errorHandler(resultStatusData.TaskId,
                          taskStatus,
                          details);
           }
-          catch (Exception e2)
+          catch (Exception e)
           {
-            Logger.LogError("An error occured while handling a Task error.\n{e2}\n{e}",
-                            e2,
+            Logger?.LogError(e,
+                            "An error occured while handling a Task error {status}: {details}",
+                            taskStatus,
                             details);
           }
         }
@@ -393,7 +400,6 @@ public class Service : AbstractClientService
                              (taskId,
                               byteResult) =>
                              {
-                               Logger?.LogTrace("responseHandler for {taskId}", taskId);
                                try
                                {
                                  var result = ProtoSerializer.DeSerializeMessageObjectArray(byteResult);
@@ -439,9 +445,6 @@ public class Service : AbstractClientService
                               taskStatus,
                               ex) =>
                              {
-                               Logger?.LogTrace("errorHandler for {taskId}: {taskStatus}",
-                                                taskId,
-                                                taskStatus);
                                try
                                {
                                  var statusCode = StatusCodesLookUp.Keys.Contains(taskStatus)

--- a/UnifiedApi/Client/Services/Submitter/Service.cs
+++ b/UnifiedApi/Client/Services/Submitter/Service.cs
@@ -304,6 +304,9 @@ public class Service : AbstractClientService
           }
           catch (Exception e)
           {
+            Logger.LogWarning("resultHandler for {taskId} threw an error: {e}",
+                              resultStatusData.TaskId,
+                              e);
             try
             {
               errorHandler(resultStatusData.TaskId,
@@ -390,6 +393,7 @@ public class Service : AbstractClientService
                              (taskId,
                               byteResult) =>
                              {
+                               Logger?.LogTrace("responseHandler for {taskId}", taskId);
                                try
                                {
                                  var result = ProtoSerializer.DeSerializeMessageObjectArray(byteResult);
@@ -435,6 +439,9 @@ public class Service : AbstractClientService
                               taskStatus,
                               ex) =>
                              {
+                               Logger?.LogTrace("errorHandler for {taskId}: {taskStatus}",
+                                                taskId,
+                                                taskStatus);
                                try
                                {
                                  var statusCode = StatusCodesLookUp.Keys.Contains(taskStatus)

--- a/UnifiedApi/Client/Services/Submitter/Service.cs
+++ b/UnifiedApi/Client/Services/Submitter/Service.cs
@@ -285,7 +285,8 @@ public class Service : AbstractClientService
 
     while (missing.Count != 0)
     {
-      foreach (var bucket in missing.Batch(500))
+      foreach (var bucket in missing.ToList()
+                                    .Batch(500))
       {
         var resultStatusCollection = SessionService.GetResultStatus(bucket);
 
@@ -307,8 +308,8 @@ public class Service : AbstractClientService
           catch (Exception e)
           {
             Logger?.LogWarning(e,
-                              "resultHandler for {taskId} threw an error",
-                              resultStatusData.TaskId);
+                               "resultHandler for {taskId} threw an error",
+                               resultStatusData.TaskId);
             try
             {
               errorHandler(resultStatusData.TaskId,
@@ -318,8 +319,8 @@ public class Service : AbstractClientService
             catch (Exception e2)
             {
               Logger?.LogError(e2,
-                              "An error occured while handling another error: {details}",
-                              e);
+                               "An error occured while handling another error: {details}",
+                               e);
             }
           }
         }
@@ -359,9 +360,9 @@ public class Service : AbstractClientService
           catch (Exception e)
           {
             Logger?.LogError(e,
-                            "An error occured while handling a Task error {status}: {details}",
-                            taskStatus,
-                            details);
+                             "An error occured while handling a Task error {status}: {details}",
+                             taskStatus,
+                             details);
           }
         }
 


### PR DESCRIPTION
An exception in errorHandler would bubble up to the get result loop, and thus ends this loop.
A few try-catch have been added to continue to fetch results even in case of errors.