### PR TITLE
Fixing issue where an unrecoverable failure of a task could be retried

### DIFF
--- a/WorkerApi/ArmoniK.DevelopmentKit.WorkerApi/AppsLoader.cs
+++ b/WorkerApi/ArmoniK.DevelopmentKit.WorkerApi/AppsLoader.cs
@@ -70,24 +70,28 @@ public class AppsLoader : IAppsLoader
 
     UserAssemblyLoadContext = new AddonsAssemblyLoadContext(localPathToAssembly);
 
-    assembly_ = UserAssemblyLoadContext.LoadFromAssemblyPath(localPathToAssembly);
-
-    if (assembly_ == null)
+    try
     {
-      logger_.LogError($"Cannot load assembly from path [${localPathToAssembly}]");
-      throw new WorkerApiException($"Cannot load assembly from path [${localPathToAssembly}]");
+      assembly_ = UserAssemblyLoadContext.LoadFromAssemblyPath(localPathToAssembly);
+    }
+    catch (Exception ex)
+    {
+      logger_.LogError($"Cannot load assembly from path [${localPathToAssembly}] "             + ex.Message + Environment.NewLine + ex.StackTrace);
+      throw new WorkerApiException($"Cannot load assembly from path [${localPathToAssembly}] " + ex.Message + Environment.NewLine + ex.StackTrace);
     }
 
     PathToAssembly = localPathToAssembly;
 
     var localPathToAssemblyGridWorker = $"{Path.GetDirectoryName(localPathToAssembly)}/{ArmoniKDevelopmentKitServerApi}.dll";
 
-    assemblyGridWorker_ = UserAssemblyLoadContext.LoadFromAssemblyPath(localPathToAssemblyGridWorker);
-
-    if (assemblyGridWorker_ == null)
+    try
     {
-      logger_.LogError($"Cannot load assembly from path [${localPathToAssemblyGridWorker}]");
-      throw new WorkerApiException($"Cannot load assembly from path [${localPathToAssemblyGridWorker}]");
+      assemblyGridWorker_ = UserAssemblyLoadContext.LoadFromAssemblyPath(localPathToAssemblyGridWorker);
+    }
+    catch (Exception ex)
+    {
+      logger_.LogError($"Cannot load assembly from path [${localPathToAssemblyGridWorker}] "             + ex.Message + Environment.NewLine + ex.StackTrace);
+      throw new WorkerApiException($"Cannot load assembly from path [${localPathToAssemblyGridWorker}] " + ex.Message + Environment.NewLine + ex.StackTrace);
     }
 
     var location = Path.GetDirectoryName(localPathToAssembly);

--- a/WorkerApi/ArmoniK.DevelopmentKit.WorkerApi/Services/ComputerService.cs
+++ b/WorkerApi/ArmoniK.DevelopmentKit.WorkerApi/Services/ComputerService.cs
@@ -155,13 +155,13 @@ public class ComputerService : WorkerStreamWrapper
       Logger.LogError(ex,
                       "WorkerAPIException failure while executing task");
 
-      output = new Output
-               {
-                 Error = new Output.Types.Error
-                         {
-                           Details = ex.Message + Environment.NewLine + ex.StackTrace,
-                         },
-               };
+      return new Output
+             {
+               Error = new Output.Types.Error
+                       {
+                         Details = ex.Message + Environment.NewLine + ex.StackTrace,
+                       },
+             };
     }
 
     catch (Exception ex)

--- a/WorkerApi/ArmoniK.DevelopmentKit.WorkerApi/Services/ComputerService.cs
+++ b/WorkerApi/ArmoniK.DevelopmentKit.WorkerApi/Services/ComputerService.cs
@@ -155,8 +155,13 @@ public class ComputerService : WorkerStreamWrapper
       Logger.LogError(ex,
                       "WorkerAPIException failure while executing task");
 
-      throw new RpcException(new Status(StatusCode.Aborted,
-                                        ex.Message + Environment.NewLine + ex.StackTrace));
+      output = new Output
+               {
+                 Error = new Output.Types.Error
+                         {
+                           Details = ex.Message,
+                         },
+               };
     }
 
     catch (Exception ex)

--- a/WorkerApi/ArmoniK.DevelopmentKit.WorkerApi/Services/ComputerService.cs
+++ b/WorkerApi/ArmoniK.DevelopmentKit.WorkerApi/Services/ComputerService.cs
@@ -159,7 +159,7 @@ public class ComputerService : WorkerStreamWrapper
                {
                  Error = new Output.Types.Error
                          {
-                           Details = ex.Message,
+                           Details = ex.Message + Environment.NewLine + ex.StackTrace,
                          },
                };
     }


### PR DESCRIPTION
This should fix an issue where if the worker is in a bad state (no dll, asked function doesn't exist), the task would still be retried.
Fix based on this flow : https://github.com/aneoconsulting/ArmoniK.Core/blob/main/Documentation/articles/tasks.md
The task will not be retried anymore if such exception arises

fix https://github.com/aneoconsulting/ArmoniK/issues/584