### PR TITLE
Reinsert submit task for unified api

### DIFF
--- a/Tests/EndToEnd.Tests/Tests/CheckSubtaskingTreeUnifiedApi/SubtaskingTreeUnifiedApiClient.cs
+++ b/Tests/EndToEnd.Tests/Tests/CheckSubtaskingTreeUnifiedApi/SubtaskingTreeUnifiedApiClient.cs
@@ -1,0 +1,149 @@
+// This file is part of the ArmoniK project
+//
+// Copyright (C) ANEO, 2021-$CURRENT_YEAR$. All rights reserved.
+//   W. Kirschenmann   <wkirschenmann@aneo.fr>
+//   J. Gurhem         <jgurhem@aneo.fr>
+//   D. Dubuc          <ddubuc@aneo.fr>
+//   L. Ziane Khodja   <lzianekhodja@aneo.fr>
+//   F. Lemaitre       <flemaitre@aneo.fr>
+//   S. Djebbar        <sdjebbar@aneo.fr>
+//   J. Fonseca        <jfonseca@aneo.fr>
+//   D. Brasseur       <dbrasseur@aneo.fr>
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY, without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+using ArmoniK.Api.gRPC.V1;
+using ArmoniK.DevelopmentKit.Client.Exceptions;
+using ArmoniK.DevelopmentKit.Client.Factory;
+using ArmoniK.DevelopmentKit.Client.Services;
+using ArmoniK.DevelopmentKit.Client.Services.Submitter;
+using ArmoniK.DevelopmentKit.Common;
+using ArmoniK.EndToEndTests.Common;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace ArmoniK.EndToEndTests.Tests.CheckSubtaskingTreeUnifiedApi;
+
+public class SubtaskingTreeUnifiedApiClient : ClientBaseTest<SubtaskingTreeUnifiedApiClient>, IServiceInvocationHandler
+{
+  private readonly Dictionary<string, int> expectedIntegerResults_ = new();
+
+  public SubtaskingTreeUnifiedApiClient(IConfiguration configuration,
+                                        ILoggerFactory loggerFactory)
+    : base(configuration,
+           loggerFactory)
+  {
+  }
+
+  /// <summary>
+  ///   The callBack method which has to be implemented to retrieve error or exception
+  /// </summary>
+  /// <param name="e">The exception sent to the client from the control plane</param>
+  /// <param name="taskId">The task identifier which has invoked the error callBack</param>
+  public void HandleError(ServiceInvocationException e,
+                          string                     taskId)
+  {
+    Log.LogError($"Error from {taskId} : " + e.Message);
+    throw new ApplicationException($"Error from {taskId}",
+                                   e);
+  }
+
+  /// <summary>
+  ///   The callBack method which has to be implemented to retrieve response from the server
+  /// </summary>
+  /// <param name="response">The object received from the server as result the method called by the client</param>
+  /// <param name="taskId">The task identifier which has invoked the response callBack</param>
+  public void HandleResponse(object response,
+                             string taskId)
+  {
+    switch (response)
+    {
+      case null:
+        Log.LogInformation("Task finished but nothing returned in Result");
+        break;
+      case double value:
+        Log.LogInformation($"Task finished with result {value}");
+        break;
+      case double[] doubles:
+        Log.LogInformation("Result is " + string.Join(", ",
+                                                      doubles));
+        break;
+      case byte[] values:
+        var result = ClientPayload.Deserialize(values);
+        Log.LogInformation($"Result is {result.Result} expected is : {expectedIntegerResults_[taskId]}");
+        Assert.AreEqual(expectedIntegerResults_[taskId],
+                        result.Result);
+        break;
+    }
+  }
+
+
+  [EntryPoint]
+  public override void EntryPoint()
+  {
+    Log.LogInformation("Configure taskOptions");
+    var taskOptions = InitializeTaskOptions();
+    OverrideTaskOptions(taskOptions);
+
+    taskOptions.ApplicationService  = "SubtaskingTreeUnifiedApiWorker";
+    taskOptions.MaxDuration.Seconds = 1800;
+
+    var props = new Properties(taskOptions,
+                               Configuration.GetSection("Grpc")["EndPoint"],
+                               5001);
+
+    using var cs = ServiceFactory.CreateService(props,
+                                                LoggerFactory);
+
+    Log.LogInformation("Running End to End test to compute Sum of numbers with subtasking");
+    SumNumbersWithSubtasking(cs);
+  }
+
+  private static void OverrideTaskOptions(TaskOptions taskOptions)
+    => taskOptions.EngineType = EngineType.Unified.ToString();
+
+  private static object[] ParamsHelper(params object[] elements)
+    => elements;
+
+
+  private void SumNumbersWithSubtasking(Service sessionService,
+                                        int     maxNumberToSum    = 16,
+                                        int     subtaskSplitCount = 2)
+  {
+    Log.LogInformation($"Launching Sum of numbers 1 to {maxNumberToSum}");
+    var numbers = Enumerable.Range(1,
+                                   maxNumberToSum)
+                            .ToList();
+    var payload = new ClientPayload
+                  {
+                    IsRootTask = true,
+                    Numbers    = numbers,
+                    NbSubTasks = subtaskSplitCount,
+                    Type       = ClientPayload.TaskType.None,
+                  };
+
+    var sw = Stopwatch.StartNew();
+
+
+    var taskId = sessionService.Submit("ComputeSubTaskingTreeSum",
+                                       ParamsHelper(payload.Serialize()),
+                                       this);
+    expectedIntegerResults_[taskId] = numbers.Sum();
+  }
+}

--- a/Tests/EndToEnd.Tests/Tests/CheckSubtaskingTreeUnifiedApi/SubtaskingTreeUnifiedApiWorker.cs
+++ b/Tests/EndToEnd.Tests/Tests/CheckSubtaskingTreeUnifiedApi/SubtaskingTreeUnifiedApiWorker.cs
@@ -1,0 +1,189 @@
+// This file is part of the ArmoniK project
+// 
+// Copyright (C) ANEO, 2021-2022. All rights reserved.
+//   W. Kirschenmann   <wkirschenmann@aneo.fr>
+//   J. Gurhem         <jgurhem@aneo.fr>
+//   D. Dubuc          <ddubuc@aneo.fr>
+//   L. Ziane Khodja   <lzianekhodja@aneo.fr>
+//   F. Lemaitre       <flemaitre@aneo.fr>
+//   S. Djebbar        <sdjebbar@aneo.fr>
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+// 
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using ArmoniK.DevelopmentKit.Common;
+using ArmoniK.DevelopmentKit.Common.Exceptions;
+using ArmoniK.DevelopmentKit.Worker.Grid;
+using ArmoniK.EndToEndTests.Common;
+
+using Microsoft.Extensions.Logging;
+
+namespace ArmoniK.EndToEndTests.Tests.CheckSubtaskingTreeUnifiedApi;
+
+public class SubtaskingTreeUnifiedApiWorker : TaskSubmitterWorkerService
+{
+  public void CheckPayload(ClientPayload payload)
+  {
+    if (payload == null)
+    {
+      throw new ArgumentException("CheckPayload: payload must not be null");
+    }
+
+    if (payload.Type != ClientPayload.TaskType.Aggregation)
+    {
+      if (payload.Numbers == null)
+      {
+        throw new ArgumentException("CheckPayload: payload numbers must not be null");
+      }
+
+      if (payload.NbSubTasks <= 1)
+      {
+        throw new ArgumentException($"CheckPayload: payload.NbSubTasks:{payload.NbSubTasks} must be >= 2");
+      }
+    }
+  }
+
+  private static IEnumerable<T[]> SplitList<T>(List<T> listToSplit,
+                                               int     nbSplit = 2)
+    => listToSplit.Chunk((int)Math.Ceiling(listToSplit.Count / (decimal)nbSplit));
+
+  public byte[] ComputeSubTaskingTreeSum(byte[] clientPayload)
+  {
+    Logger.LogInformation("Enter in function : SplitAndSum taskID : {TaskId}",
+                          TaskContext.TaskId);
+
+    var payload = ClientPayload.Deserialize(clientPayload);
+    CheckPayload(payload);
+
+    if (payload.Numbers.Count == 0)
+    {
+      return new ClientPayload
+             {
+               Type   = ClientPayload.TaskType.Result,
+               Result = 0,
+             }.Serialize(); // Nothing to do
+    }
+
+    if (payload.Numbers.Count == 1)
+    {
+      var value = payload.Numbers[0];
+      Logger.LogInformation("final tree {value}",
+                            value);
+
+      return new ClientPayload
+             {
+               Type   = ClientPayload.TaskType.Result,
+               Result = value,
+             }.Serialize();
+    }
+
+    // if (clientPayload.numbers.Count > 1)
+    var splittedLists = SplitList(payload.Numbers,
+                                  payload.NbSubTasks);
+
+    var subTaskIds = new List<string>(payload.NbSubTasks);
+    foreach (var splittedList in splittedLists)
+    {
+      var childPayload = new ClientPayload
+                         {
+                           Type       = payload.Type,
+                           Numbers    = splittedList.ToList(),
+                           NbSubTasks = payload.NbSubTasks,
+                           Result     = 0,
+                         };
+      if (splittedList.Count() <= 100)
+      {
+        Logger.LogInformation("Submitting subTask, numbers : [{Numbers}] payload type : {PayloadType}",
+                              string.Join(';',
+                                          splittedList),
+                              payload.Type);
+      }
+      else
+      {
+        Logger.LogInformation("Submitting subTask, numbers : [{NumbersFrom};...;{NumbersTo}]",
+                              string.Join(';',
+                                          splittedList.Take(50)),
+                              string.Join(';',
+                                          splittedList.TakeLast(50)));
+      }
+
+      var subTaskId = SubmitTask("ComputeSubTaskingTreeSum",
+                                 ParamsHelper(childPayload.Serialize()));
+      subTaskIds.Add(subTaskId);
+    }
+
+    ClientPayload aggPayload = new()
+                               {
+                                 Type   = ClientPayload.TaskType.Aggregation,
+                                 Result = 0,
+                               };
+
+    Logger.LogInformation("Submitting aggregation task");
+    var aggTaskId = SubmitTaskWithDependencies(nameof(AggregateValues),
+                                               ParamsHelper(aggPayload.Serialize()),
+                                               subTaskIds,
+                                               true);
+
+    Logger.LogInformation("Submitted  SubmitTaskWithDependencies : {aggTaskId} with task dependencies {subtaskIds}...",
+                          aggTaskId,
+                          string.Join(';',
+                                      subTaskIds.Take(10)));
+
+    return null; //nothing to do
+  }
+
+  private static object[] ParamsHelper(params object[] elements)
+    => elements;
+
+
+  public byte[] AggregateValues(byte[] serializedClientPayload)
+  {
+    var clientPayload = ClientPayload.Deserialize(serializedClientPayload);
+
+    Logger.LogInformation("Aggregate Task. Request result from Dependencies TaskIds : {DependenciesTaskIds}",
+                          string.Join(", ",
+                                      TaskContext.DependenciesTaskIds.Take(10)));
+    var aggregatedValuesSum = 0;
+    var dependencyValues    = new List<int>();
+    foreach (var taskDependency in TaskContext.DataDependencies)
+    {
+      if (taskDependency.Value == null || taskDependency.Value.Length == 0)
+      {
+        throw new WorkerApiException($"Cannot retrieve result from taskId {TaskContext.DependenciesTaskIds?.Single()}");
+      }
+
+      var deprot                  = ProtoSerializer.DeSerializeMessageObjectArray(taskDependency.Value);
+      var dependencyResultPayload = ClientPayload.Deserialize(deprot[0] as byte[]);
+      dependencyValues.Add(dependencyResultPayload.Result);
+      aggregatedValuesSum += dependencyResultPayload.Result;
+    }
+
+    Logger.LogInformation("Aggregation has summed parents data dependencies {dependencyValues}, result = {aggregatedValuesSum}",
+                          string.Join("+",
+                                      dependencyValues),
+                          aggregatedValuesSum);
+    aggregatedValuesSum += clientPayload.Result;
+
+    ClientPayload aggregationResults = new()
+                                       {
+                                         Type   = ClientPayload.TaskType.Result,
+                                         Result = aggregatedValuesSum,
+                                       };
+
+    return aggregationResults.Serialize();
+  }
+}

--- a/Tests/EndToEnd.Tests/Tests/CheckSubtaskingTreeUnifiedApi/SubtaskingTreeUnifiedApiWorker.cs
+++ b/Tests/EndToEnd.Tests/Tests/CheckSubtaskingTreeUnifiedApi/SubtaskingTreeUnifiedApiWorker.cs
@@ -59,7 +59,7 @@ public class SubtaskingTreeUnifiedApiWorker : TaskSubmitterWorkerService
 
   private static IEnumerable<T[]> SplitList<T>(List<T> listToSplit,
                                                int     nbSplit = 2)
-    => listToSplit.Chunk((int)Math.Ceiling(listToSplit.Count / (decimal)nbSplit));
+    => listToSplit.Chunk((int)Math.Ceiling(listToSplit.Count / (float)nbSplit));
 
   public byte[] ComputeSubTaskingTreeSum(byte[] clientPayload)
   {

--- a/Tests/EndToEnd.Tests/Tests/CheckSubtaskingTree_SymphonySDK/SubtaskingTreeClient.cs
+++ b/Tests/EndToEnd.Tests/Tests/CheckSubtaskingTree_SymphonySDK/SubtaskingTreeClient.cs
@@ -34,7 +34,6 @@ using Microsoft.Extensions.Logging;
 
 namespace ArmoniK.EndToEndTests.Tests.CheckSubtaskingTree_SymphonySDK;
 
-[Disabled]
 public class SubtaskingTreeClient : ClientBaseTest<SubtaskingTreeClient>
 {
   public SubtaskingTreeClient(IConfiguration configuration,
@@ -44,7 +43,6 @@ public class SubtaskingTreeClient : ClientBaseTest<SubtaskingTreeClient>
   {
   }
 
-  [EntryPoint]
   public override void EntryPoint()
   {
     var client = new ArmonikSymphonyClient(Configuration,

--- a/UnifiedApi/Worker/Grid/GridWorker.cs
+++ b/UnifiedApi/Worker/Grid/GridWorker.cs
@@ -99,6 +99,12 @@ public class GridWorker : IGridWorker
 
     ServiceClass = appsLoader.GetServiceContainerInstance<object>(GridAppNamespace,
                                                                   GridServiceName);
+
+    if (ServiceClass is ITaskSubmitterWorkerServiceConfiguration serviceContext)
+    {
+      serviceContext.Configure(configuration,
+                               clientOptions);
+    }
   }
 
   public void InitializeSessionWorker(Session     session,
@@ -139,6 +145,21 @@ public class GridWorker : IGridWorker
                                  .GetMethod(methodName,
                                             arguments.Select(x => x.GetType())
                                                      .ToArray());
+
+    if (ServiceClass is ITaskSubmitterWorkerServiceConfiguration serviceContext)
+    {
+      var taskContext = new TaskContext
+                        {
+                          TaskId              = taskHandler.TaskId,
+                          TaskInput           = taskHandler.Payload,
+                          SessionId           = taskHandler.SessionId,
+                          DependenciesTaskIds = taskHandler.DataDependencies.Select(t => t.Key),
+                          DataDependencies    = taskHandler.DataDependencies,
+                        };
+      serviceContext.TaskContext = taskContext;
+      serviceContext.ConfigureSessionService(taskHandler);
+    }
+
     if (methodInfo == null)
     {
       throw new
@@ -186,10 +207,7 @@ public class GridWorker : IGridWorker
       throw new WorkerApiException(e);
     }
 
-
-    return new byte[]
-           {
-           };
+    return null;
   }
 
   public void SessionFinalize()

--- a/UnifiedApi/Worker/Grid/ITaskSubmitterWorkerServiceConfiguration.cs
+++ b/UnifiedApi/Worker/Grid/ITaskSubmitterWorkerServiceConfiguration.cs
@@ -1,0 +1,39 @@
+// This file is part of the ArmoniK project
+//
+// Copyright (C) ANEO, 2021-$CURRENT_YEAR$. All rights reserved.
+//   W. Kirschenmann   <wkirschenmann@aneo.fr>
+//   J. Gurhem         <jgurhem@aneo.fr>
+//   D. Dubuc          <ddubuc@aneo.fr>
+//   L. Ziane Khodja   <lzianekhodja@aneo.fr>
+//   F. Lemaitre       <flemaitre@aneo.fr>
+//   S. Djebbar        <sdjebbar@aneo.fr>
+//   J. Fonseca        <jfonseca@aneo.fr>
+//   D. Brasseur       <dbrasseur@aneo.fr>
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY, without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using ArmoniK.Api.gRPC.V1;
+using ArmoniK.Api.Worker.Worker;
+
+using Microsoft.Extensions.Configuration;
+
+namespace ArmoniK.DevelopmentKit.Worker.Grid;
+
+internal interface ITaskSubmitterWorkerServiceConfiguration
+{
+  TaskContext TaskContext { get; set; }
+  void        ConfigureSessionService(ITaskHandler taskHandler);
+
+  void Configure(IConfiguration configuration,
+                 TaskOptions    clientOptions);
+}

--- a/UnifiedApi/Worker/Grid/TaskSubmitterWorkerService.cs
+++ b/UnifiedApi/Worker/Grid/TaskSubmitterWorkerService.cs
@@ -1,0 +1,358 @@
+// This file is part of the ArmoniK project
+// 
+// Copyright (C) ANEO, 2021-2022.
+//   W. Kirschenmann   <wkirschenmann@aneo.fr>
+//   J. Gurhem         <jgurhem@aneo.fr>
+//   D. Dubuc          <ddubuc@aneo.fr>
+//   L. Ziane Khodja   <lzianekhodja@aneo.fr>
+//   F. Lemaitre       <flemaitre@aneo.fr>
+//   S. Djebbar        <sdjebbar@aneo.fr>
+//   J. Fonseca        <jfonseca@aneo.fr>
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using ArmoniK.Api.gRPC.V1;
+using ArmoniK.Api.Worker.Worker;
+using ArmoniK.DevelopmentKit.Common;
+using ArmoniK.DevelopmentKit.WorkerApi.Common;
+
+using JetBrains.Annotations;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+using Serilog;
+using Serilog.Formatting.Compact;
+
+using ILogger = Microsoft.Extensions.Logging.ILogger;
+
+namespace ArmoniK.DevelopmentKit.Worker.Grid;
+
+/// <summary>
+///   This is an abstract class that have to be implemented
+///   by each class who needs tasks submission on worker side
+///   See an example in the project ArmoniK.Samples in the sub project
+///   https://github.com/aneoconsulting/ArmoniK.Samples/tree/main/Samples/UnifiedAPI
+///   ArmoniK.Samples.Worker/Services/ServiceApps.cs
+/// </summary>
+[PublicAPI]
+[MarkDownDoc]
+public abstract class TaskSubmitterWorkerService : ITaskSubmitterWorkerServiceConfiguration
+{
+  /// <summary>
+  /// </summary>
+  public TaskSubmitterWorkerService()
+  {
+    Configuration = GridWorkerExt.GetDefaultConfiguration();
+    Logger = GridWorkerExt.GetDefaultLoggerFactory(Configuration)
+                          .CreateLogger(GetType()
+                                          .Name);
+  }
+
+  /// <summary>
+  /// </summary>
+  /// <param name="loggerFactory">The factory logger to create logger</param>
+  public TaskSubmitterWorkerService(ILoggerFactory loggerFactory)
+  {
+    LoggerFactory = loggerFactory;
+
+    Logger = loggerFactory.CreateLogger(GetType()
+                                          .Name);
+  }
+
+  /// <summary>
+  ///   Get access to Logger with Logger.LoggingScope.
+  /// </summary>
+  public ILogger Logger { get; set; }
+
+  /// <summary>
+  ///   Get or Set SubSessionId object stored during the call of SubmitTask, SubmitSubTask,
+  ///   SubmitSubTaskWithDependencies or WaitForCompletion, WaitForSubTaskCompletion or GetResults
+  /// </summary>
+  public Session SessionId { get; set; }
+
+  /// <summary>
+  ///   Property to retrieve the sessionService previously created
+  /// </summary>
+  internal SessionPollingService SessionService { get; set; }
+
+  /// <summary>
+  ///   Map between ids of task and their results id after task submission
+  /// </summary>
+  public Dictionary<string, string> TaskId2OutputId
+    => SessionService.TaskId2OutputId;
+
+  //internal ITaskHandler TaskHandler { get; set; }
+
+  /// <summary>
+  ///   Return TaskOption coming from Client side
+  /// </summary>
+  public TaskOptions TaskOptions { get; set; } = new();
+
+  /// <summary>
+  ///   Get or Set Configuration
+  /// </summary>
+  public IConfiguration Configuration { get; set; }
+
+  /// <summary>
+  ///   The logger factory to create new Logger in sub class caller
+  /// </summary>
+  public ILoggerFactory LoggerFactory { get; set; }
+
+  public TaskContext TaskContext { get; set; }
+
+  /// <summary>
+  ///   The configure method is an internal call to prepare the ServiceContainer.
+  ///   Its holds several configuration coming from the Client call
+  /// </summary>
+  /// <param name="configuration">The appSettings.json configuration prepared during the deployment</param>
+  /// <param name="clientOptions">All data coming from Client within TaskOptions </param>
+  public void Configure(IConfiguration configuration,
+                        TaskOptions    clientOptions)
+  {
+    Configuration = configuration;
+
+    var logger = new LoggerConfiguration().ReadFrom.Configuration(Configuration)
+                                          .WriteTo.Console(new CompactJsonFormatter())
+                                          .Enrich.FromLogContext()
+                                          .CreateLogger();
+    LoggerFactory = Microsoft.Extensions.Logging.LoggerFactory.Create(loggingBuilder => loggingBuilder.AddSerilog(logger));
+    Logger = LoggerFactory.CreateLogger(GetType()
+                                          .Name);
+    Logger.LogInformation("Configuring ServiceContainerBase");
+  }
+
+  /// <summary>
+  ///   Configure Service for actual session. Connect the worker to the current pollingAgent
+  /// </summary>
+  /// <param name="taskHandler">Low level object used for tasks submission by <see cref="SessionPollingService" /> </param>
+  public void ConfigureSessionService(ITaskHandler taskHandler)
+    => SessionService = new SessionPollingService(LoggerFactory,
+                                                  taskHandler);
+
+  /// <summary>
+  ///   The middleware triggers the invocation of this handler just after a Service Instance is started.
+  ///   The application developer must put any service initialization into this handler.
+  ///   Default implementation does nothing.
+  /// </summary>
+  /// <param name="serviceContext">
+  ///   Holds all information on the state of the service at the start of the execution.
+  /// </param>
+  public void OnCreateService(ServiceContext serviceContext)
+  {
+  }
+
+
+  /// <summary>
+  ///   This handler is executed once after the callback OnCreateService and before the OnInvoke
+  /// </summary>
+  /// <param name="sessionContext">
+  ///   Holds all information on the state of the session at the start of the execution.
+  /// </param>
+  public void OnSessionEnter(SessionContext sessionContext)
+  {
+  }
+
+  /// <summary>
+  ///   The middleware triggers the invocation of this handler to unbind the Service Instance from its owning Session.
+  ///   This handler should do any cleanup for any resources that were used in the onSessionEnter() method.
+  /// </summary>
+  /// <param name="sessionContext">
+  ///   Holds all information on the state of the session at the start of the execution such as session ID.
+  /// </param>
+  public void OnSessionLeave(SessionContext sessionContext)
+  {
+  }
+
+
+  /// <summary>
+  ///   The middleware triggers the invocation of this handler just before a Service Instance is destroyed.
+  ///   This handler should do any cleanup for any resources that were used in the onCreateService() method.
+  /// </summary>
+  /// <param name="serviceContext">
+  ///   Holds all information on the state of the service at the start of the execution.
+  /// </param>
+  public void OnDestroyService(ServiceContext serviceContext)
+  {
+  }
+
+  /// <summary>
+  ///   User method to submit task from the service
+  /// </summary>
+  /// <param name="payloads">
+  ///   The user payload list to execute. Generally used for subTasking.
+  /// </param>
+  public IEnumerable<string> SubmitTasks(IEnumerable<byte[]> payloads)
+    => SessionService.SubmitTasks(payloads);
+
+
+  /// <summary>
+  ///   The method to submit several tasks with dependencies tasks. This task will wait
+  ///   until all dependencies are completed successfully before starting
+  /// </summary>
+  /// <param name="payloadWithDependencies">A list of Tuple(taskId, Payload) in dependence of those created tasks</param>
+  /// <param name="resultForParent">Transmit the result to parent task if true</param>
+  /// <returns>return a list of taskIds of the created tasks </returns>
+  public IEnumerable<string> SubmitTasksWithDependencies(IEnumerable<Tuple<byte[], IList<string>>> payloadWithDependencies,
+                                                         bool                                      resultForParent = false)
+    => SessionService.SubmitTasksWithDependencies(payloadWithDependencies,
+                                                  resultForParent);
+
+
+  /// <summary>
+  ///   User method to submit task from the service
+  /// </summary>
+  /// <param name="payload">
+  ///   The user payload to execute. Generally used for subtasking.
+  /// </param>
+  public string SubmitTask(byte[] payload)
+    => SessionService.SubmitTasks(new[]
+                                  {
+                                    payload,
+                                  })
+                     .Single();
+
+
+  /// <summary>
+  ///   User method to submit task from the service
+  /// </summary>
+  /// <param name="methodName">
+  ///   The name of the method you want to call
+  ///   <remarks>It is case sensitive</remarks>
+  /// </param>
+  /// <param name="arguments">The arguments of the method to call </param>
+  public string SubmitTask(string   methodName,
+                           object[] arguments)
+  {
+    var protoSerializer = new ProtoSerializer();
+    ArmonikPayload armonikPayload = new()
+                                    {
+                                      ArmonikRequestType  = ArmonikRequestType.Execute,
+                                      MethodName          = methodName,
+                                      ClientPayload       = protoSerializer.SerializeMessageObjectArray(arguments),
+                                      SerializedArguments = false,
+                                    };
+    return SessionService.SubmitTasks(new[]
+                                      {
+                                        armonikPayload.Serialize(),
+                                      })
+                         .Single();
+  }
+
+
+  /// <summary>
+  ///   The method to submit One task with dependencies tasks. This task will wait for
+  ///   to start until all dependencies are completed successfully
+  /// </summary>
+  /// <param name="payload">The payload to submit</param>
+  /// <param name="dependencies">A list of task Id in dependence of this created task</param>
+  /// <param name="resultForParent"></param>
+  /// <returns>return the taskId of the created task </returns>
+  public string SubmitTaskWithDependencie(byte[]        payload,
+                                          IList<string> dependencies,
+                                          bool          resultForParent = false)
+    => SessionService.SubmitTasksWithDependencies(new[]
+                                                  {
+                                                    Tuple.Create(payload,
+                                                                 dependencies),
+                                                  },
+                                                  resultForParent)
+                     .Single();
+
+  /// <summary>
+  ///   The method to submit One task with dependencies tasks. This task will wait for
+  ///   to start until all dependencies are completed successfully
+  /// </summary>
+  /// <param name="methodName"></param>
+  /// <param name="arguments">The arguments to submit</param>
+  /// <param name="dependencies">A list of task Id in dependence of this created task</param>
+  /// <param name="resultForParent"></param>
+  /// <returns>return the taskId of the created task </returns>
+  public string SubmitTaskWithDependencies(string        methodName,
+                                           object[]      arguments,
+                                           IList<string> dependencies,
+                                           bool          resultForParent = false)
+  {
+    var protoSerializer = new ProtoSerializer();
+    ArmonikPayload armonikPayload = new()
+                                    {
+                                      ArmonikRequestType  = ArmonikRequestType.Execute,
+                                      MethodName          = methodName,
+                                      ClientPayload       = protoSerializer.SerializeMessageObjectArray(arguments),
+                                      SerializedArguments = false,
+                                    };
+    return SessionService.SubmitTasksWithDependencies(new[]
+                                                      {
+                                                        Tuple.Create(armonikPayload.Serialize(),
+                                                                     dependencies),
+                                                      },
+                                                      resultForParent)
+                         .Single();
+  }
+
+  /// <summary>
+  ///   User method to wait for only the parent task from the client
+  /// </summary>
+  /// <param name="taskId">
+  ///   The task id of the task to wait for
+  /// </param>
+  [Obsolete]
+  public void WaitForTaskCompletion(string taskId)
+  {
+  }
+
+  /// <summary>
+  /// </summary>
+  /// <param name="taskIds">List of tasks to wait for</param>
+  [Obsolete]
+  public void WaitForTasksCompletion(IEnumerable<string> taskIds)
+  {
+  }
+
+  /// <summary>
+  ///   User method to wait for SubTasks from the client
+  /// </summary>
+  /// <param name="taskId">
+  ///   The task id of the Subtask
+  /// </param>
+  [Obsolete]
+  public void WaitForSubTasksCompletion(string taskId)
+  {
+  }
+
+  /// <summary>
+  ///   Get Result from compute reply
+  /// </summary>
+  /// <param name="taskId">The task Id to get the result</param>
+  /// <returns>return the customer payload</returns>
+  public byte[] GetDependenciesResult(string taskId)
+    => SessionService.GetDependenciesResult(taskId);
+
+  /// <summary>
+  ///   Prepare Session and create SessionService with the specific session
+  /// </summary>
+  /// <param name="sessionId">The ID of the current session</param>
+  /// <param name="requestTaskOptions">The default <see cref="TaskOptions" /> used by tasks in the current session</param>
+  public void ConfigureSession(Session     sessionId,
+                               TaskOptions requestTaskOptions)
+  {
+    SessionId = sessionId;
+
+    //Append or overwrite Dictionary Options in TaskOptions with one coming from client
+    TaskOptions = requestTaskOptions;
+  }
+}


### PR DESCRIPTION
Rem : 
in Tests/EndToEnd.Tests/Tests/CheckSubtaskingTreeUnifiedApi/SubtaskingTreeUnifiedApiWorker.cs L174
I have wrotten : 
      object[] deprot = ProtoSerializer.DeSerializeMessageObjectArray(taskDependency.Value);
      var dependencyResultPayload = ClientPayload.Deserialize(deprot[0] as byte[]);
but it's strange for me taskDependency.Value must be my data type but not the internal armonik serialization type
Rem2: TaskSubmitterWorkerService.cs is kind of copy/paste of BaseService<T>.cs
if validated next step to removeBaseService.cs ? or don't touch if Dylan is already refactoring.

goal :
Add possibility to submit task from worker pod/zip(unified API)
Add possibility to submit task with dependencies from worker pod/zip(unified API)
Add EndToEndTest with subtasking (similar to CheckSubtaskingTree_SymphonySDK.SubtaskingTreeClient)