### PR TITLE
fix: Set log from info to debug

### DIFF
--- a/Worker/src/DLLWorker/Services/ComputerService.cs
+++ b/Worker/src/DLLWorker/Services/ComputerService.cs
@@ -52,7 +52,7 @@ public class ComputerService : WorkerStreamWrapper
     Configuration         = configuration;
     Logger                = serviceRequestContext.LoggerFactory.CreateLogger<ComputerService>();
     ServiceRequestContext = serviceRequestContext;
-    Logger.LogInformation("Starting worker...OK");
+    Logger.LogDebug("Starting worker...OK");
   }
 
   private ILogger<ComputerService> Logger { get; }


### PR DESCRIPTION
Avoid unnecessary logging in WorkerService