### PR TITLE
renaming TaskSubmitterWorkerService to TaskWorkerService

### DIFF
--- a/Tests/ArmoniK.EndToEndTests/ArmoniK.EndToEndTests.Worker/Tests/CheckSubtaskingTreeUnifiedApi/SubtaskingTreeUnifiedApiWorker.cs
+++ b/Tests/ArmoniK.EndToEndTests/ArmoniK.EndToEndTests.Worker/Tests/CheckSubtaskingTreeUnifiedApi/SubtaskingTreeUnifiedApiWorker.cs
@@ -34,7 +34,7 @@ using Microsoft.Extensions.Logging;
 
 namespace ArmoniK.EndToEndTests.Worker.Tests.CheckSubtaskingTreeUnifiedApi;
 
-public class SubtaskingTreeUnifiedApiWorker : TaskSubmitterWorkerService
+public class SubtaskingTreeUnifiedApiWorker : TaskWorkerService
 {
   public void CheckPayload(ClientPayload payload)
   {

--- a/Tests/ArmoniK.EndToEndTests/ArmoniK.EndToEndTests.Worker/Tests/CheckUnifiedApi/SimpleUnfiedAPITest.cs
+++ b/Tests/ArmoniK.EndToEndTests/ArmoniK.EndToEndTests.Worker/Tests/CheckUnifiedApi/SimpleUnfiedAPITest.cs
@@ -30,7 +30,7 @@ using ArmoniK.DevelopmentKit.Worker.Unified.Exceptions;
 
 namespace ArmoniK.EndToEndTests.Worker.Tests.CheckUnifiedApi;
 
-public class CheckUnifiedApiWorker : TaskSubmitterWorkerService
+public class CheckUnifiedApiWorker : TaskWorkerService
 {
   private readonly Random rd = new();
 

--- a/Tests/ArmoniK.EndToEndTests/ArmoniK.EndToEndTests.Worker/Tests/PayloadIntegrityTestWorker/Services/ServiceApps.cs
+++ b/Tests/ArmoniK.EndToEndTests/ArmoniK.EndToEndTests.Worker/Tests/PayloadIntegrityTestWorker/Services/ServiceApps.cs
@@ -2,7 +2,7 @@ using ArmoniK.DevelopmentKit.Worker.Unified;
 
 namespace ArmoniK.EndToEndTests.Worker.Tests.PayloadIntegrityTestWorker.Services;
 
-public class ServiceApps : TaskSubmitterWorkerService
+public class ServiceApps : TaskWorkerService
 {
   public static string CopyPayload(string inputs)
     => inputs;

--- a/Worker/src/Unified/GridWorker.cs
+++ b/Worker/src/Unified/GridWorker.cs
@@ -157,7 +157,7 @@ public class GridWorker : IGridWorker
                                                    .ToArray());
     }
 
-    if (ServiceClass is ITaskSubmitterWorkerServiceConfiguration serviceContext)
+    if (ServiceClass is ITaskWorkerServiceConfiguration serviceContext)
     {
       var taskContext = new TaskContext
                         {

--- a/Worker/src/Unified/ILoggerConfiguration.cs
+++ b/Worker/src/Unified/ILoggerConfiguration.cs
@@ -26,7 +26,16 @@ using Microsoft.Extensions.Configuration;
 
 namespace ArmoniK.DevelopmentKit.Worker.Unified;
 
-internal interface ILoggerConfiguration
+/// <summary>
+///   implementation of this interface in <see cref="TaskWorkerService" /> or your own implementation allows to have a
+///   logger configured automatically by the <see cref="GridWorker" />
+/// </summary>
+public interface ILoggerConfiguration
 {
+  /// <summary>
+  ///   The configure method is an internal call to prepare the ServiceContainer.
+  ///   Its holds several configuration coming from the Client call
+  /// </summary>
+  /// <param name="configuration">The appSettings.json configuration prepared during the deployment</param>
   void ConfigureLogger(IConfiguration configuration);
 }

--- a/Worker/src/Unified/ITaskOptionsConfiguration.cs
+++ b/Worker/src/Unified/ITaskOptionsConfiguration.cs
@@ -26,7 +26,16 @@ using ArmoniK.Api.gRPC.V1;
 
 namespace ArmoniK.DevelopmentKit.Worker.Unified;
 
-internal interface ITaskOptionsConfiguration
+/// <summary>
+///   implementation of this interface in <see cref="TaskWorkerService" /> or your own implementation allows to have the
+///   <see cref="TaskOptions" /> configured automatically by the <see cref="GridWorker" />
+/// </summary>
+public interface ITaskOptionsConfiguration
 {
+  /// <summary>
+  ///   The configure method is an internal call to prepare the ServiceContainer.
+  ///   Its holds TaskOptions coming from the Client call
+  /// </summary>
+  /// <param name="clientOptions">All data coming from Client within TaskOptions </param>
   void ConfigureTaskOptions(TaskOptions clientOptions);
 }

--- a/Worker/src/Unified/ITaskSubmitterWorkerServiceConfiguration.cs
+++ b/Worker/src/Unified/ITaskSubmitterWorkerServiceConfiguration.cs
@@ -26,8 +26,20 @@ using ArmoniK.Api.Worker.Worker;
 
 namespace ArmoniK.DevelopmentKit.Worker.Unified;
 
-internal interface ITaskSubmitterWorkerServiceConfiguration
+/// <summary>
+///   implementation of this interface in <see cref="TaskWorkerService" /> or your own implementation allows to have the
+///   <see cref="ITaskHandler" /> configured automatically by the <see cref="GridWorker" />
+/// </summary>
+public interface ITaskWorkerServiceConfiguration
 {
+  /// <summary>
+  ///   Provides the context for the task that is bound to the given service invocation
+  /// </summary>
   TaskContext TaskContext { get; set; }
-  void        ConfigureSessionService(ITaskHandler taskHandler);
+
+  /// <summary>
+  ///   Configure Service for actual session. Connect the worker to the current pollingAgent
+  /// </summary>
+  /// <param name="taskHandler">Low level object used for tasks submission by <see cref="SessionPollingService" /> </param>
+  void ConfigureSessionService(ITaskHandler taskHandler);
 }

--- a/Worker/src/Unified/TaskSubmitterWorkerService.cs
+++ b/Worker/src/Unified/TaskSubmitterWorkerService.cs
@@ -44,18 +44,18 @@ namespace ArmoniK.DevelopmentKit.Worker.Unified;
 
 /// <summary>
 ///   This is an abstract class that have to be implemented
-///   by each class who needs tasks submission on worker side
+///   by each class who needs context or tasks submission on worker side
 ///   See an example in the project ArmoniK.Samples in the sub project
 ///   https://github.com/aneoconsulting/ArmoniK.Samples/tree/main/Samples/UnifiedAPI
 ///   ArmoniK.Samples.Worker/Services/ServiceApps.cs
 /// </summary>
 [PublicAPI]
 [MarkDownDoc]
-public abstract class TaskSubmitterWorkerService : ITaskSubmitterWorkerServiceConfiguration, ITaskOptionsConfiguration, ILoggerConfiguration
+public abstract class TaskWorkerService : ITaskWorkerServiceConfiguration, ITaskOptionsConfiguration, ILoggerConfiguration
 {
   /// <summary>
   /// </summary>
-  public TaskSubmitterWorkerService()
+  protected TaskWorkerService()
   {
     Configuration = WorkerHelpers.GetDefaultConfiguration();
     Logger = WorkerHelpers.GetDefaultLoggerFactory(Configuration)
@@ -66,7 +66,7 @@ public abstract class TaskSubmitterWorkerService : ITaskSubmitterWorkerServiceCo
   /// <summary>
   /// </summary>
   /// <param name="loggerFactory">The factory logger to create logger</param>
-  public TaskSubmitterWorkerService(ILoggerFactory loggerFactory)
+  protected TaskWorkerService(ILoggerFactory loggerFactory)
   {
     LoggerFactory = loggerFactory;
 
@@ -113,11 +113,7 @@ public abstract class TaskSubmitterWorkerService : ITaskSubmitterWorkerServiceCo
   /// </summary>
   public ILoggerFactory LoggerFactory { get; set; }
 
-  /// <summary>
-  ///   The configure method is an internal call to prepare the ServiceContainer.
-  ///   Its holds several configuration coming from the Client call
-  /// </summary>
-  /// <param name="configuration">The appSettings.json configuration prepared during the deployment</param>
+  /// <inheritdoc />
   public void ConfigureLogger(IConfiguration configuration)
   {
     Configuration = configuration;
@@ -132,23 +128,14 @@ public abstract class TaskSubmitterWorkerService : ITaskSubmitterWorkerServiceCo
     Logger.LogInformation("Configuring ServiceContainerBase");
   }
 
-  /// <summary>
-  ///   The configure method is an internal call to prepare the ServiceContainer.
-  ///   Its holds TaskOptions coming from the Client call
-  /// </summary>
-  /// <param name="clientOptions">All data coming from Client within TaskOptions </param>
+  /// <inheritdoc />
   public void ConfigureTaskOptions(TaskOptions clientOptions)
     => TaskOptions = clientOptions;
 
-  /// <summary>
-  ///   Provides the context for the task that is bound to the given service invocation
-  /// </summary>
+  /// <inheritdoc />
   public TaskContext TaskContext { get; set; }
 
-  /// <summary>
-  ///   Configure Service for actual session. Connect the worker to the current pollingAgent
-  /// </summary>
-  /// <param name="taskHandler">Low level object used for tasks submission by <see cref="SessionPollingService" /> </param>
+  /// <inheritdoc />
   public void ConfigureSessionService(ITaskHandler taskHandler)
     => SessionService = new SessionPollingService(LoggerFactory,
                                                   taskHandler);
@@ -288,4 +275,23 @@ public abstract class TaskSubmitterWorkerService : ITaskSubmitterWorkerServiceCo
     //Append or overwrite Dictionary Options in TaskOptions with one coming from client
     TaskOptions = requestTaskOptions;
   }
+}
+
+/// <summary>
+///   This is an abstract class that have to be implemented
+///   by each class who needs context or tasks submission on worker side
+///   See an example in the project ArmoniK.Samples in the sub project
+///   https://github.com/aneoconsulting/ArmoniK.Samples/tree/main/Samples/UnifiedAPI
+///   ArmoniK.Samples.Worker/Services/ServiceApps.cs
+/// </summary>
+/// <remarks>
+///   WARNING : TaskSubmitterWorkerService has been replaced by TaskWorkerService.
+///   This class will stay in 2.12 for compatibility reasons
+///   This class will be removed in armonik 2.13
+/// </remarks>
+[PublicAPI]
+[MarkDownDoc]
+[Obsolete("TaskSubmitterWorkerService has been replaced by TaskWorkerService")]
+public abstract class TaskSubmitterWorkerService : TaskWorkerService
+{
 }


### PR DESCRIPTION
just renaming class TaskSubmitterWorkerService  as TaskWorkerService
still keeping old class name as an 'alias' with obsolete tag