### PR TITLE
move pack output files manually

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,7 +147,9 @@ jobs:
     # find . -name "*.csproj" | xargs -I % echo dotnet pack % -c Release -o /tmp/packages -p:Version=\$GENVERSION
     - name: Pack the package VERSION
       run: |
-        dotnet pack ArmoniK.Extensions.Csharp.sln -c Release -o /tmp/packages -p:Version=$GENVERSION
+        dotnet pack ArmoniK.Extensions.Csharp.sln -c Release -p:Version=$GENVERSION
+        mkdir -p /tmp/packages
+        mv ./publish/*.* /tmp/packages/
 
     - name: Store the package VERSION
       uses: actions/upload-artifact@v3
@@ -159,7 +161,9 @@ jobs:
     - name: Pack the package RELEASE
       if: ${{ github.ref == 'refs/heads/release' }}
       run: |
-        dotnet pack ArmoniK.Extensions.Csharp.sln -c Release -o /tmp/releases -p:Version=$GENRELEASE
+        dotnet pack ArmoniK.Extensions.Csharp.sln -c Release -p:Version=$GENRELEASE
+        mkdir -p /tmp/releases
+        mv ./publish/*.* /tmp/releases/
 
     - name: Store the package RELEASE
       if: ${{ github.ref == 'refs/heads/release' }}


### PR DESCRIPTION
2 points : 
1/ default github image we are using : 'runs-on: ubuntu-latest', already install dotnet versions : https://github.com/actions/runner-images/blob/ubuntu22/20230217.1/images/linux/Ubuntu2204-Readme.md
so in our factory when we are performing dotnet install step : uses: actions/setup-dotnet@v3 in fact v7 is already installed
when we are using dotnet build or pack it is the v7 who is used

2/ in the new 7.0.200 dotnet release : https://learn.microsoft.com/en-us/dotnet/core/compatibility/7.0#sdk-and-msbuild
you can see that the -output parameter on solution is deprecated and generate an error : 
https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/7.0/solution-level-output-no-longer-valid

=> that's why we have this error : "error NETSDK1194: The "--output" option isn't supported when building a solution."
default output for 'dotnet pack' is in ./generated folder
=>fix is to move the output files manually to the desired output