### PR TITLE
fix: Issue with no TLS and windows 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -206,7 +206,7 @@ jobs:
 
       - id: deploy
         name: Deploy
-        uses: aneoconsulting/ArmoniK.Action.Deploy/deploy@main
+        uses: aneoconsulting/ArmoniK.Action.Deploy/deploy@dd/fixUploadArtifact
         with:
           working-directory: ${{ github.workspace }}/infra
           type: localhost

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -206,7 +206,7 @@ jobs:
 
       - id: deploy
         name: Deploy
-        uses: aneoconsulting/ArmoniK.Action.Deploy/deploy@dd/fixUploadArtifact
+        uses: aneoconsulting/ArmoniK.Action.Deploy/deploy@main
         with:
           working-directory: ${{ github.workspace }}/infra
           type: localhost

--- a/Client/src/Common/Submitter/ClientServiceConnector.cs
+++ b/Client/src/Common/Submitter/ClientServiceConnector.cs
@@ -1,3 +1,5 @@
+using System;
+
 using ArmoniK.Api.Client.Options;
 using ArmoniK.Api.Client.Submitter;
 
@@ -33,12 +35,12 @@ public class ClientServiceConnector
                     OverrideTargetName    = properties.TargetNameOverride,
                   };
 
-    if (options.AllowUnsafeConnection && string.IsNullOrEmpty(options.OverrideTargetName))
+    if (properties.ControlPlaneUri.Scheme == Uri.UriSchemeHttps && options.AllowUnsafeConnection && string.IsNullOrEmpty(options.OverrideTargetName))
     {
 #if NET5_0_OR_GREATER
       var doOverride = !string.IsNullOrEmpty(options.CaCert);
 #else
-      var doOverride = properties.ControlPlaneUri.Scheme.Contains("https");
+      var doOverride = true;
 #endif
       if (doOverride)
       {

--- a/Client/src/Common/Submitter/ClientServiceConnector.cs
+++ b/Client/src/Common/Submitter/ClientServiceConnector.cs
@@ -38,7 +38,7 @@ public class ClientServiceConnector
 #if NET5_0_OR_GREATER
       var doOverride = !string.IsNullOrEmpty(options.CaCert);
 #else
-      var doOverride = true;
+      var doOverride = properties.ControlPlaneUri.Scheme.Contains("https");
 #endif
       if (doOverride)
       {


### PR DESCRIPTION
Need to fix in ArmoniK.Api. There is no need to override target name when there is no TLS at all
fix: https://github.com/aneoconsulting/ArmoniK/issues/1090