### PR TITLE
fix: Use strong name for Utils

### DIFF
--- a/Common/src/Common/ArmoniK.DevelopmentKit.Common.csproj
+++ b/Common/src/Common/ArmoniK.DevelopmentKit.Common.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
  <ItemGroup>
-    <PackageReference Include="ArmoniK.Utils" Version="0.1.0" />
+    <PackageReference Include="ArmoniK.Utils" Version="0.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
     <PackageReference Include="protobuf-net" Version="3.1.22" />


### PR DESCRIPTION
Strong name has been added to ArmoniK.Utils in version 0.2.0