### PR TITLE
chore: update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,13 @@
   "rangeStrategy": "bump",
   "packageRules": [
     {
+      "groupName": "npm packages",
+      "groupSlug": "npm",
+      "matchDatasources": [
+        "npm"
+      ]
+    },
+    {
       "groupName": "nuget packages",
       "groupSlug": "nuget",
       "matchDatasources": [

--- a/renovate.json
+++ b/renovate.json
@@ -1,20 +1,33 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base",
-              "group:allNonMajor",
-              ":semanticCommits"
-             ],
-  "packageRules":
-  [
+  "extends": [
+    "config:base",
+    "group:allNonMajor",
+    ":semanticCommitTypeAll(chore)",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "rangeStrategy": "bump",
+  "packageRules": [
     {
-      "matchPackagePrefixes": ["ArmoniK"],
-      "groupName": "release packages Armonik"
+      "groupName": "nuget packages",
+      "groupSlug": "nuget",
+      "matchDatasources": [
+        "nuget"
+      ]
     },
     {
-
-    "matchPackagePatterns": ["*"],
-    "excludePackagePrefixes": ["ArmoniK"],
-    "groupName": "other dependencies"  
+      "groupName": "docker images",
+      "groupSlug": "docker",
+      "matchDatasources": [
+        "docker"
+      ]
+    },
+    {
+      "groupName": "github actions",
+      "groupSlug": "github-actions",
+      "matchDatasources": [
+        "github-tags"
+      ]
     }
   ]
 }


### PR DESCRIPTION
This PR update config in order to group deps by datasources.

For security, we need to pin actions.

An example: https://github.com/esoubiran-aneo/ArmoniK.Extensions.Csharp