### PR TITLE
ci: Fixes and reduces nunit tests

### DIFF
--- a/Tests/ArmoniK.EndToEndTests/ArmoniK.EndToEndTests.Client/Tests/AggregationPriority/AggregationPriorityTest.cs
+++ b/Tests/ArmoniK.EndToEndTests/ArmoniK.EndToEndTests.Client/Tests/AggregationPriority/AggregationPriorityTest.cs
@@ -319,6 +319,7 @@ public class AggregationPriorityTest
   /// </summary>
   /// <param name="squareMatrixSize">The size of the square matrix.</param>
   [TestCase(20)]
+  [Ignore("Too big")]
   public void Check_That_Result_has_expected_value(int squareMatrixSize)
   {
     unifiedTestHelper_.Log.LogInformation($"Compute square matrix with n =  {squareMatrixSize}");

--- a/Tests/ArmoniK.EndToEndTests/ArmoniK.EndToEndTests.Client/Tests/UnitTestHelperBase.cs
+++ b/Tests/ArmoniK.EndToEndTests/ArmoniK.EndToEndTests.Client/Tests/UnitTestHelperBase.cs
@@ -101,9 +101,8 @@ internal abstract class UnitTestHelperBase
                                         applicationNamespace,
                                         applicationService);
 
-    Props = new Properties(TaskOptions,
-                           Configuration.GetSection("Grpc")["EndPoint"],
-                           5001);
+    Props = new Properties(Configuration,
+                           TaskOptions);
   }
 
   public static object[] ParamsHelper(params object[] elements)


### PR DESCRIPTION
The aggregation priority test is too big and doesn't test extc# explicitely, so it should be ignored. This also fixes a configuration of the UnifiedTestHelperBase