### PR TITLE
fix: Acquire channel within retry loops

### DIFF
--- a/Client/src/Common/Submitter/BaseClientSubmitter.cs
+++ b/Client/src/Common/Submitter/BaseClientSubmitter.cs
@@ -223,16 +223,16 @@ public class BaseClientSubmitter<T>
   {
     using var _ = Logger?.LogFunction();
 
-    using var channel          = channelPool_.GetChannel();
-    var       submitterService = new Api.gRPC.V1.Submitter.Submitter.SubmitterClient(channel);
-
-    var serviceConfiguration = submitterService.GetServiceConfigurationAsync(new Empty())
-                                               .ResponseAsync.Result;
-
     for (var nbRetry = 0; nbRetry < maxRetries; nbRetry++)
     {
       try
       {
+        using var channel          = channelPool_.GetChannel();
+        var       submitterService = new Api.gRPC.V1.Submitter.Submitter.SubmitterClient(channel);
+
+        var serviceConfiguration = submitterService.GetServiceConfigurationAsync(new Empty())
+                                                   .ResponseAsync.Result;
+
         using var asyncClientStreamingCall = submitterService.CreateLargeTasks();
 
         asyncClientStreamingCall.RequestStream.WriteAsync(new CreateLargeTaskRequest
@@ -397,13 +397,13 @@ public class BaseClientSubmitter<T>
   {
     using var _ = Logger?.LogFunction();
 
-    using var channel          = channelPool_.GetChannel();
-    var       submitterService = new Api.gRPC.V1.Submitter.Submitter.SubmitterClient(channel);
-
     Retry.WhileException(5,
                          2000,
                          retry =>
                          {
+                           using var channel          = channelPool_.GetChannel();
+                           var       submitterService = new Api.gRPC.V1.Submitter.Submitter.SubmitterClient(channel);
+
                            if (retry > 1)
                            {
                              Logger?.LogWarning("Try {try} for {funcName}",
@@ -454,13 +454,13 @@ public class BaseClientSubmitter<T>
                                                                        ResultStatus.Notfound))
                          : Array.Empty<ResultStatusData>();
 
-    using var channel          = channelPool_.GetChannel();
-    var       submitterService = new Api.gRPC.V1.Submitter.Submitter.SubmitterClient(channel);
-
     var idStatus = Retry.WhileException(5,
                                         2000,
                                         retry =>
                                         {
+                                          using var channel          = channelPool_.GetChannel();
+                                          var       submitterService = new Api.gRPC.V1.Submitter.Submitter.SubmitterClient(channel);
+
                                           Logger?.LogDebug("Try {try} for {funcName}",
                                                            retry,
                                                            nameof(submitterService.GetResultStatus));
@@ -579,13 +579,13 @@ public class BaseClientSubmitter<T>
                           Session  = SessionId.Id,
                         };
 
-    using var channel          = channelPool_.GetChannel();
-    var       submitterService = new Api.gRPC.V1.Submitter.Submitter.SubmitterClient(channel);
-
     Retry.WhileException(5,
                          2000,
                          retry =>
                          {
+                           using var channel          = channelPool_.GetChannel();
+                           var       submitterService = new Api.gRPC.V1.Submitter.Submitter.SubmitterClient(channel);
+
                            Logger?.LogDebug("Try {try} for {funcName}",
                                             retry,
                                             nameof(submitterService.WaitForAvailability));


### PR DESCRIPTION
Move channel acquire inside the retry loop to avoid getting the same channel over and over