### PR TITLE
fix: Bad property override

### DIFF
--- a/Client/src/Common/Properties.cs
+++ b/Client/src/Common/Properties.cs
@@ -88,7 +88,7 @@ public class Properties
                     string      clientKeyPem   = null,
                     string      clientP12      = null,
                     string      caCertPem      = null,
-                    bool        sslValidation  = true)
+                    bool?       sslValidation  = null)
     : this(new ConfigurationBuilder().AddEnvironmentVariables()
                                      .Build(),
            options,
@@ -126,7 +126,7 @@ public class Properties
                     string         clientKeyFilePem  = null,
                     string         clientP12         = null,
                     string         caCertPem         = null,
-                    bool           sslValidation     = true)
+                    bool?          sslValidation     = null)
   {
     TaskOptions   = options;
     Configuration = configuration;
@@ -143,6 +143,7 @@ public class Properties
                                     .Exists()
                            ? sectionGrpc[SectionEndPoint]
                            : null;
+
       ConfSSLValidation = !sectionGrpc.GetSection(SectionSSlValidation)
                                       .Exists() || sectionGrpc[SectionSSlValidation] != "disable";
 
@@ -168,6 +169,10 @@ public class Properties
                         ? sectionGrpc[SectionClientCertP12]
                         : null;
     }
+    else
+    {
+      ConfSSLValidation = true;
+    }
 
     if (clientCertFilePem != null)
     {
@@ -189,7 +194,10 @@ public class Properties
       CaCertFilePem = caCertPem;
     }
 
-    ConfSSLValidation = sslValidation && ConfSSLValidation;
+    if (sslValidation.HasValue)
+    {
+      ConfSSLValidation = sslValidation.Value;
+    }
 
     //Console.WriteLine($"Parameters coming from Properties :\n" +
     //                  $"ConnectionString  = {ConnectionString}\n" +

--- a/Client/src/Common/Properties.cs
+++ b/Client/src/Common/Properties.cs
@@ -143,7 +143,7 @@ public class Properties
 
       if (!string.IsNullOrEmpty(uri.Scheme))
       {
-        Protocol = protocol ?? uri.Scheme;
+        Protocol = uri.Scheme;
       }
     }
     else
@@ -151,7 +151,7 @@ public class Properties
       ConnectionString = sectionGrpc?[SectionEndPoint];
     }
 
-    Protocol ??= protocol;
+    Protocol = protocol ?? Protocol;
 
     ConfSSLValidation  = sslValidation ?? sectionGrpc?[SectionSSlValidation] != "disable";
     TargetNameOverride = sectionGrpc?[SectionTargetNameOverride];
@@ -171,7 +171,7 @@ public class Properties
       throw new ArgumentException($"Issue with the connection point : {ConnectionString}");
     }
 
-    ControlPlaneUri = new Uri(ConnectionString);
+    ControlPlaneUri = new Uri(ConnectionString!);
   }
 
   /// <summary>

--- a/Client/src/Common/Properties.cs
+++ b/Client/src/Common/Properties.cs
@@ -136,77 +136,6 @@ public class Properties
                         ? configuration.GetSection(SectionGrpc)
                         : null;
 
-
-    if (sectionGrpc != null)
-    {
-      ConnectionString = sectionGrpc.GetSection(SectionEndPoint)
-                                    .Exists()
-                           ? sectionGrpc[SectionEndPoint]
-                           : null;
-
-      ConfSSLValidation = !sectionGrpc.GetSection(SectionSSlValidation)
-                                      .Exists() || sectionGrpc[SectionSSlValidation] != "disable";
-
-      TargetNameOverride = sectionGrpc.GetSection(SectionTargetNameOverride)
-                                      .Exists()
-                             ? sectionGrpc[TargetNameOverride]
-                             : null;
-
-      CaCertFilePem = sectionGrpc.GetSection(SectionCaCert)
-                                 .Exists()
-                        ? sectionGrpc[SectionCaCert]
-                        : null;
-      ClientCertFilePem = sectionGrpc.GetSection(SectionClientCert)
-                                     .Exists()
-                            ? sectionGrpc[SectionClientCert]
-                            : null;
-      ClientKeyFilePem = sectionGrpc.GetSection(SectionClientKey)
-                                    .Exists()
-                           ? sectionGrpc[SectionClientKey]
-                           : null;
-      ClientP12File = sectionGrpc.GetSection(SectionClientCertP12)
-                                 .Exists()
-                        ? sectionGrpc[SectionClientCertP12]
-                        : null;
-    }
-    else
-    {
-      ConfSSLValidation = true;
-    }
-
-    if (clientCertFilePem != null)
-    {
-      ClientCertFilePem = clientCertFilePem;
-    }
-
-    if (clientKeyFilePem != null)
-    {
-      ClientKeyFilePem = clientKeyFilePem;
-    }
-
-    if (clientP12 != null)
-    {
-      ClientP12File = clientP12;
-    }
-
-    if (caCertPem != null)
-    {
-      CaCertFilePem = caCertPem;
-    }
-
-    if (sslValidation.HasValue)
-    {
-      ConfSSLValidation = sslValidation.Value;
-    }
-
-    //Console.WriteLine($"Parameters coming from Properties :\n" +
-    //                  $"ConnectionString  = {ConnectionString}\n" +
-    //                  $"ConfSSLValidation = {ConfSSLValidation}\n" +
-    //                  $"CaCertFilePem     = {CaCertFilePem}\n" +
-    //                  $"ClientCertFilePem = {ClientCertFilePem}\n" +
-    //                  $"ClientKeyFilePem  = {ClientKeyFilePem}\n"
-    //                  );
-
     if (connectionAddress != null)
     {
       var uri = new Uri(connectionAddress);
@@ -214,22 +143,30 @@ public class Properties
 
       if (!string.IsNullOrEmpty(uri.Scheme))
       {
-        Protocol = uri.Scheme;
+        Protocol = protocol ?? uri.Scheme;
       }
     }
+    else
+    {
+      ConnectionString = sectionGrpc?[SectionEndPoint];
+    }
+
+    Protocol ??= protocol;
+
+    ConfSSLValidation  = sslValidation ?? sectionGrpc?[SectionSSlValidation] != "disable";
+    TargetNameOverride = sectionGrpc?[SectionTargetNameOverride];
+    CaCertFilePem      = caCertPem         ?? sectionGrpc?[SectionCaCert];
+    ClientCertFilePem  = clientCertFilePem ?? sectionGrpc?[SectionClientCert];
+    ClientKeyFilePem   = clientKeyFilePem  ?? sectionGrpc?[SectionClientKey];
+    ClientP12File      = clientP12         ?? sectionGrpc?[SectionClientCertP12];
 
     if (connectionPort != 0)
     {
       ConnectionPort = connectionPort;
     }
 
-    if (protocol != null)
-    {
-      Protocol = protocol;
-    }
-
     //Check if Uri is correct
-    if (Protocol == "err://" || ConnectionAddress == "NoEndPoint" || ConnectionPort == 0)
+    if (string.IsNullOrEmpty(Protocol) || string.IsNullOrEmpty(ConnectionAddress) || ConnectionPort == 0)
     {
       throw new ArgumentException($"Issue with the connection point : {ConnectionString}");
     }


### PR DESCRIPTION
Note : The ssl validation now defaults to true if no configuration is given at all.
If a configuration file/ environnement variable is given, then it defaults to it.
If a SSLValidation option is given, then if applies it instead