### PR TITLE
refactor: remove submitter from Wait for results method in client part

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,7 +181,7 @@ jobs:
           tls: ${{ matrix.tls }}
           mtls: ${{ matrix.mtls }}
           ext-csharp-version: ${{ needs.versionning.outputs.version }}
-          core-version: 0.19.3
+          core-version: 0.20.0-SNAPSHOT.48.8762fb31
 
       - name: Setup hosts file
         run : echo -e "$(kubectl get svc ingress -n armonik -o jsonpath={.status.loadBalancer.ingress[0].ip})\tarmonik.local" | sudo tee -a /etc/hosts
@@ -304,7 +304,7 @@ jobs:
           working-directory: ${{ github.workspace }}/infra
           type: localhost
           ext-csharp-version: ${{ needs.versionning.outputs.version }}
-          core-version: 0.19.3
+          core-version: 0.20.0-SNAPSHOT.48.8762fb31
 
       - name: Run Test
         timeout-minutes: 20

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,7 +181,7 @@ jobs:
           tls: ${{ matrix.tls }}
           mtls: ${{ matrix.mtls }}
           ext-csharp-version: ${{ needs.versionning.outputs.version }}
-          core-version: 0.20.0-SNAPSHOT.48.8762fb31
+          core-version: 0.20.0
 
       - name: Setup hosts file
         run : echo -e "$(kubectl get svc ingress -n armonik -o jsonpath={.status.loadBalancer.ingress[0].ip})\tarmonik.local" | sudo tee -a /etc/hosts
@@ -304,7 +304,7 @@ jobs:
           working-directory: ${{ github.workspace }}/infra
           type: localhost
           ext-csharp-version: ${{ needs.versionning.outputs.version }}
-          core-version: 0.20.0-SNAPSHOT.48.8762fb31
+          core-version: 0.20.0
 
       - name: Run Test
         timeout-minutes: 20

--- a/Client/src/Common/Exceptions/ResultAbortedException.cs
+++ b/Client/src/Common/Exceptions/ResultAbortedException.cs
@@ -1,0 +1,36 @@
+// This file is part of the ArmoniK project
+//
+// Copyright (C) ANEO, 2021-$CURRENT_YEAR$. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+using System;
+
+namespace ArmoniK.DevelopmentKit.Client.Common.Exceptions;
+
+/// <summary>
+///   Exception when result is aborted
+/// </summary>
+public class ResultAbortedException : Exception
+
+{
+  /// <summary>
+  ///   Initializes a new instance of the <see cref="ResultAbortedException" /> with the specified error message
+  /// </summary>
+  /// <param name="message">The error message</param>
+  public ResultAbortedException(string message)
+    : base(message)
+  {
+  }
+}

--- a/Client/src/Common/Submitter/BaseClientSubmitter.cs
+++ b/Client/src/Common/Submitter/BaseClientSubmitter.cs
@@ -22,7 +22,6 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using ArmoniK.Api.Client;
-using ArmoniK.Api.Client.Submitter;
 using ArmoniK.Api.Common.Utils;
 using ArmoniK.Api.gRPC.V1;
 using ArmoniK.Api.gRPC.V1.Events;

--- a/Client/src/Common/Submitter/BaseClientSubmitter.cs
+++ b/Client/src/Common/Submitter/BaseClientSubmitter.cs
@@ -16,13 +16,13 @@
 
 using System;
 using System.Collections.Generic;
-using System.Data;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
 using ArmoniK.Api.Client;
+using ArmoniK.Api.Client.Submitter;
 using ArmoniK.Api.Common.Utils;
 using ArmoniK.Api.gRPC.V1;
 using ArmoniK.Api.gRPC.V1.Events;
@@ -676,7 +676,6 @@ public abstract class BaseClientSubmitter<T>
                             ResultId = resultId,
                             Session  = SessionId.Id,
                           };
-
       using var channel      = ChannelPool.GetChannel();
       var       eventsClient = new Events.EventsClient(channel);
       eventsClient.WaitForResultsAsync(SessionId.Id,

--- a/Client/src/Common/Submitter/BaseClientSubmitter.cs
+++ b/Client/src/Common/Submitter/BaseClientSubmitter.cs
@@ -1,13 +1,13 @@
 // This file is part of the ArmoniK project
-// 
+//
 // Copyright (C) ANEO, 2021-2023. All rights reserved.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,6 +25,7 @@ using System.Threading.Tasks;
 using ArmoniK.Api.Client;
 using ArmoniK.Api.Common.Utils;
 using ArmoniK.Api.gRPC.V1;
+using ArmoniK.Api.gRPC.V1.Events;
 using ArmoniK.Api.gRPC.V1.Results;
 using ArmoniK.Api.gRPC.V1.Sessions;
 using ArmoniK.Api.gRPC.V1.SortDirection;
@@ -676,39 +677,15 @@ public abstract class BaseClientSubmitter<T>
                             Session  = SessionId.Id,
                           };
 
-      Retry.WhileException(5,
-                           2000,
-                           retry =>
-                           {
-                             using var channel          = ChannelPool.GetChannel();
-                             var       submitterService = new Api.gRPC.V1.Submitter.Submitter.SubmitterClient(channel);
-
-                             Logger.LogDebug("Try {try} for {funcName}",
-                                             retry,
-                                             nameof(submitterService.WaitForAvailability));
-                             // TODO: replace with submitterService.TryGetResultStream() => Issue #
-                             var availabilityReply = submitterService.WaitForAvailability(resultRequest,
-                                                                                          cancellationToken: cancellationToken);
-
-                             switch (availabilityReply.TypeCase)
-                             {
-                               case AvailabilityReply.TypeOneofCase.None:
-                                 throw new Exception("Issue with Server !");
-                               case AvailabilityReply.TypeOneofCase.Ok:
-                                 break;
-                               case AvailabilityReply.TypeOneofCase.Error:
-                                 throw new
-                                   ClientResultsException($"Result in Error - {resultId}\nMessage :\n{string.Join("Inner message:\n", availabilityReply.Error.Errors)}",
-                                                          resultId);
-                               case AvailabilityReply.TypeOneofCase.NotCompletedTask:
-                                 throw new DataException($"Result {resultId} was not yet completed");
-                               default:
-                                 throw new InvalidOperationException();
-                             }
-                           },
-                           true,
-                           typeof(IOException),
-                           typeof(RpcException));
+      using var channel      = ChannelPool.GetChannel();
+      var       eventsClient = new Events.EventsClient(channel);
+      eventsClient.WaitForResultsAsync(SessionId.Id,
+                                       new List<string>
+                                       {
+                                         resultId,
+                                       },
+                                       cancellationToken)
+                  .Wait(cancellationToken);
 
       return Retry.WhileException(5,
                                   200,

--- a/Client/src/Common/Submitter/EventsClientExt.cs
+++ b/Client/src/Common/Submitter/EventsClientExt.cs
@@ -1,19 +1,18 @@
 // This file is part of the ArmoniK project
-//
-// Copyright (C) ANEO, 2021-$CURRENT_YEAR$. All rights reserved.
-//
+// 
+// Copyright (C) ANEO, 2021-2023. All rights reserved.
+// 
 // Licensed under the Apache License, Version 2.0 (the "License")
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-//
+// 
 //     http://www.apache.org/licenses/LICENSE-2.0
-//
+// 
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 using System;
 using System.Collections.Generic;
@@ -25,6 +24,8 @@ using ArmoniK.Api.gRPC.V1;
 using ArmoniK.Api.gRPC.V1.Events;
 using ArmoniK.Api.gRPC.V1.Results;
 using ArmoniK.DevelopmentKit.Client.Common.Exceptions;
+
+using Grpc.Core;
 
 namespace ArmoniK.DevelopmentKit.Client.Common.Submitter;
 
@@ -76,7 +77,8 @@ internal static class EventsClientExt
                                                                         resultsNotFound.Select(ResultsFilter),
                                                                       },
                                                                     },
-                                                 });
+                                                 },
+                                                 cancellationToken: cancellationToken);
       try
       {
         while (await streamingCall.ResponseStream.MoveNext(cancellationToken))
@@ -117,7 +119,10 @@ internal static class EventsClientExt
           }
         }
       }
-      catch (OperationCanceledException e)
+      catch (OperationCanceledException)
+      {
+      }
+      catch (RpcException)
       {
       }
     }

--- a/Client/src/Common/Submitter/EventsClientExt.cs
+++ b/Client/src/Common/Submitter/EventsClientExt.cs
@@ -1,0 +1,125 @@
+// This file is part of the ArmoniK project
+//
+// Copyright (C) ANEO, 2021-$CURRENT_YEAR$. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using ArmoniK.Api.gRPC.V1;
+using ArmoniK.Api.gRPC.V1.Events;
+using ArmoniK.Api.gRPC.V1.Results;
+using ArmoniK.DevelopmentKit.Client.Common.Exceptions;
+
+namespace ArmoniK.DevelopmentKit.Client.Common.Submitter;
+
+internal static class EventsClientExt
+{
+  private static FiltersAnd ResultsFilter(string resultId)
+    => new()
+       {
+         And =
+         {
+           new FilterField
+           {
+             Field = new ResultField
+                     {
+                       ResultRawField = new ResultRawField
+                                        {
+                                          Field = ResultRawEnumField.ResultId,
+                                        },
+                     },
+             FilterString = new FilterString
+                            {
+                              Operator = FilterStringOperator.Equal,
+                              Value    = resultId,
+                            },
+           },
+         },
+       };
+
+  private static async Task WaitForResultsAsync(this Events.EventsClient client,
+                                                string                   sessionId,
+                                                ICollection<string>      resultIds,
+                                                CancellationToken        cancellationToken)
+  {
+    var resultsNotFound = new HashSet<string>(resultIds);
+    while (resultsNotFound.Any())
+    {
+      using var streamingCall = client.GetEvents(new EventSubscriptionRequest
+                                                 {
+                                                   SessionId = sessionId,
+                                                   ReturnedEvents =
+                                                   {
+                                                     EventsEnum.ResultStatusUpdate,
+                                                     EventsEnum.NewResult,
+                                                   },
+                                                   ResultsFilters = new Filters
+                                                                    {
+                                                                      Or =
+                                                                      {
+                                                                        resultsNotFound.Select(ResultsFilter),
+                                                                      },
+                                                                    },
+                                                 });
+      try
+      {
+        while (await streamingCall.ResponseStream.MoveNext(cancellationToken))
+        {
+          var resp = streamingCall.ResponseStream.Current;
+          if (resp.UpdateCase == EventSubscriptionResponse.UpdateOneofCase.ResultStatusUpdate && resultsNotFound.Contains(resp.ResultStatusUpdate.ResultId))
+          {
+            if (resp.ResultStatusUpdate.Status == ResultStatus.Completed)
+            {
+              resultsNotFound.Remove(resp.ResultStatusUpdate.ResultId);
+              if (!resultsNotFound.Any())
+              {
+                break;
+              }
+            }
+
+            if (resp.ResultStatusUpdate.Status == ResultStatus.Aborted)
+            {
+              throw new ResultAbortedException($"Result {resp.ResultStatusUpdate.ResultId} has been aborted");
+            }
+          }
+
+          if (resp.UpdateCase == EventSubscriptionResponse.UpdateOneofCase.NewResult && resultsNotFound.Contains(resp.NewResult.ResultId))
+          {
+            if (resp.NewResult.Status == ResultStatus.Completed)
+            {
+              resultsNotFound.Remove(resp.NewResult.ResultId);
+              if (!resultsNotFound.Any())
+              {
+                break;
+              }
+            }
+
+            if (resp.NewResult.Status == ResultStatus.Aborted)
+            {
+              throw new ResultAbortedException($"Result {resp.NewResult.ResultId} has been aborted");
+            }
+          }
+        }
+      }
+      catch (OperationCanceledException e)
+      {
+      }
+    }
+  }
+}

--- a/Client/src/Common/Submitter/EventsClientExt.cs
+++ b/Client/src/Common/Submitter/EventsClientExt.cs
@@ -53,10 +53,10 @@ internal static class EventsClientExt
          },
        };
 
-  private static async Task WaitForResultsAsync(this Events.EventsClient client,
-                                                string                   sessionId,
-                                                ICollection<string>      resultIds,
-                                                CancellationToken        cancellationToken)
+  internal static async Task WaitForResultsAsync(this Events.EventsClient client,
+                                                 string                   sessionId,
+                                                 ICollection<string>      resultIds,
+                                                 CancellationToken        cancellationToken)
   {
     var resultsNotFound = new HashSet<string>(resultIds);
     while (resultsNotFound.Any())


### PR DESCRIPTION
I tried to remove the submitter from the method GetResult that waits for the results before getting them. The implementation for WaitForResults used is the same in [ArmoniK.Api](https://github.com/aneoconsulting/ArmoniK.Api/blob/main/packages/csharp/ArmoniK.Api.Client/EventsClientExt.cs). It uses the events API. Tests did not always pass. There is some unkown and "random" reason that causes the tests to crash sometimes, given that the stream received from the events api was correctly handled.