### PR TITLE
refactor: remove submitter from admin monitoring service

### DIFF
--- a/Client/src/Common/Submitter/TasksClientExt.cs
+++ b/Client/src/Common/Submitter/TasksClientExt.cs
@@ -54,6 +54,79 @@ public static class TasksClientExt
        };
 
   /// <summary>
+  ///   Filter tasks on their sessionId
+  /// </summary>
+  /// <param name="sessionId"> the session id to filter on </param>
+  /// <returns></returns>
+  public static FiltersAnd TaskSessionIdFilter(string sessionId)
+    => new()
+       {
+         And =
+         {
+           new FilterField
+           {
+             Field = new TaskField
+                     {
+                       TaskSummaryField = new TaskSummaryField
+                                          {
+                                            Field = TaskSummaryEnumField.SessionId,
+                                          },
+                     },
+             FilterString = new FilterString
+                            {
+                              Value    = sessionId,
+                              Operator = FilterStringOperator.Equal,
+                            },
+           },
+         },
+       };
+
+  /// <summary>
+  ///   Filter on task status ajd session id
+  /// </summary>
+  /// <param name="status"> the task status to filter on </param>
+  /// <param name="sessionId"> the session id to filter on </param>
+  /// <returns></returns>
+  public static FiltersAnd TaskStatusFilter(TaskStatus status,
+                                            string     sessionId)
+    => new()
+       {
+         And =
+         {
+           new FilterField
+           {
+             Field = new TaskField
+                     {
+                       TaskSummaryField = new TaskSummaryField
+                                          {
+                                            Field = TaskSummaryEnumField.Status,
+                                          },
+                     },
+             FilterStatus = new FilterStatus
+                            {
+                              Operator = FilterStatusOperator.Equal,
+                              Value    = status,
+                            },
+           },
+           new FilterField
+           {
+             Field = new TaskField
+                     {
+                       TaskSummaryField = new TaskSummaryField
+                                          {
+                                            Field = TaskSummaryEnumField.SessionId,
+                                          },
+                     },
+             FilterString = new FilterString
+                            {
+                              Operator = FilterStringOperator.Equal,
+                              Value    = sessionId,
+                            },
+           },
+         },
+       };
+
+  /// <summary>
   ///   List tasks while handling page size
   /// </summary>
   /// <param name="tasksClient"> the tasks client </param>


### PR DESCRIPTION
In this part of the code, I removed the submitter from all the functions except those who takes an argument of type TaskFilter . TaskFilter will be deprecated. 
 The functions I updated to not use the submitter need refactoring because I did'nt use ArmoniK filters to filter what output i needed. Instead I received all the outputs then used ."Select" to select the needed output. This code needs refactor to use ArmoniK filters which I began to do but didn't complete. There is one function (ListRunningTasks) where I used ArmoniK Filters. Even when using ArmoniK Filters, a lot of code can be mutualised.
Note also that the format of the code needs to be verified.