### PR TITLE
refactor: remove submitter from chunk submit with dependencies method

### DIFF
--- a/Client/src/Common/ArmoniK.DevelopmentKit.Client.Common.csproj
+++ b/Client/src/Common/ArmoniK.DevelopmentKit.Client.Common.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ArmoniK.Api.Client" Version="3.14.0" />
+    <PackageReference Include="ArmoniK.Api.Client" Version="3.15.0-edge.23.b178614" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
   </ItemGroup>

--- a/Client/src/Common/Submitter/BaseClientSubmitter.cs
+++ b/Client/src/Common/Submitter/BaseClientSubmitter.cs
@@ -290,7 +290,7 @@ public abstract class BaseClientSubmitter<T>
       var channel        = ChannelPool.GetChannel();
       var tasksClient    = new Tasks.TasksClient(channel);
       var resultsClient  = new Results.ResultsClient(channel);
-      var resultsCreated = new List<string>();
+      var tasksSubmitted = new List<string>();
       foreach (var (resultId, payload, dependencies) in payloadsWithDependencies)
       {
         try
@@ -316,7 +316,7 @@ public abstract class BaseClientSubmitter<T>
                                                            })
                                     .Results.Select(raw => raw.ResultId)
                                     .Single();
-          tasksClient.SubmitTasksAsync(new SubmitTasksRequest
+          var submitResponse = tasksClient.SubmitTasks(new SubmitTasksRequest
                                        {
                                          SessionId = SessionId.Id,
                                          TaskCreations =
@@ -336,8 +336,8 @@ public abstract class BaseClientSubmitter<T>
                                            },
                                          },
                                        });
-          resultsCreated.Add(result);
-          return resultsCreated;
+          tasksSubmitted.AddRange(submitResponse.TaskInfos.Select(taskInfo=> taskInfo.TaskId));
+          return tasksSubmitted;
         }
         catch (Exception e)
         {

--- a/Client/src/Common/Submitter/BaseClientSubmitter.cs
+++ b/Client/src/Common/Submitter/BaseClientSubmitter.cs
@@ -376,7 +376,7 @@ public abstract class BaseClientSubmitter<T>
               break;
             default:
               Logger.LogError(innerException,
-                                "Unknown failure");
+                              "Unknown failure");
               throw;
           }
 

--- a/Client/src/Common/Submitter/BaseClientSubmitter.cs
+++ b/Client/src/Common/Submitter/BaseClientSubmitter.cs
@@ -306,37 +306,28 @@ public abstract class BaseClientSubmitter<T>
                                                          },
                                                        },
                                                      });
-          var result = resultsClient.CreateResultsMetaData(new CreateResultsMetaDataRequest
-                                                           {
-                                                             SessionId = SessionId.Id,
-                                                             Results =
-                                                             {
-                                                               new CreateResultsMetaDataRequest.Types.ResultCreate(),
-                                                             },
-                                                           })
-                                    .Results.Select(raw => raw.ResultId)
-                                    .Single();
+
           var submitResponse = tasksClient.SubmitTasks(new SubmitTasksRequest
-                                       {
-                                         SessionId = SessionId.Id,
-                                         TaskCreations =
-                                         {
-                                           new SubmitTasksRequest.Types.TaskCreation
-                                           {
-                                             PayloadId = payloads.Results.Select(raw => raw.ResultId)
-                                                                 .Single(),
-                                             DataDependencies =
-                                             {
-                                               dependencies,
-                                             },
-                                             ExpectedOutputKeys =
-                                             {
-                                               result,
-                                             },
-                                           },
-                                         },
-                                       });
-          tasksSubmitted.AddRange(submitResponse.TaskInfos.Select(taskInfo=> taskInfo.TaskId));
+                                                       {
+                                                         SessionId = SessionId.Id,
+                                                         TaskCreations =
+                                                         {
+                                                           new SubmitTasksRequest.Types.TaskCreation
+                                                           {
+                                                             PayloadId = payloads.Results.Select(raw => raw.ResultId)
+                                                                                 .Single(),
+                                                             DataDependencies =
+                                                             {
+                                                               dependencies,
+                                                             },
+                                                             ExpectedOutputKeys =
+                                                             {
+                                                               resultId,
+                                                             },
+                                                           },
+                                                         },
+                                                       });
+          tasksSubmitted.AddRange(submitResponse.TaskInfos.Select(taskInfo => taskInfo.TaskId));
           return tasksSubmitted;
         }
         catch (Exception e)

--- a/Client/src/Common/Submitter/BaseClientSubmitter.cs
+++ b/Client/src/Common/Submitter/BaseClientSubmitter.cs
@@ -331,6 +331,8 @@ public abstract class BaseClientSubmitter<T>
                                                          TaskOptions = taskOptions,
                                                        });
           tasksSubmitted.AddRange(submitResponse.TaskInfos.Select(taskInfo => taskInfo.TaskId));
+          // break retry loop because submission is successful
+          break;
         }
         catch (Exception e)
         {

--- a/Client/src/Common/Submitter/BaseClientSubmitter.cs
+++ b/Client/src/Common/Submitter/BaseClientSubmitter.cs
@@ -360,29 +360,23 @@ public abstract class BaseClientSubmitter<T>
             throw;
           }
 
-          switch (e)
+          var innerException = e is AggregateException
+                                    {
+                                      InnerExceptions.Count: 1,
+                                    } agg
+                                 ? agg.InnerException
+                                 : e;
+
+          switch (innerException)
           {
-            case AggregateException
-                 {
-                   InnerException: RpcException,
-                 } ex:
-              Logger.LogWarning(ex.InnerException,
-                                "Failure to submit");
-              break;
-            case AggregateException
-                 {
-                   InnerException: IOException,
-                 } ex:
-              Logger.LogWarning(ex.InnerException,
-                                "IOException : Failure to submit, Retrying");
-              break;
-            case IOException ex:
-              Logger.LogWarning(ex,
-                                "IOException Failure to submit");
+            case RpcException:
+            case IOException:
+              Logger.LogWarning(innerException,
+                                "Failure to submit : Retrying");
               break;
             default:
-              Logger.LogError(e,
-                              "Unknown failure :");
+              Logger.LogError(innerException,
+                                "Unknown failure");
               throw;
           }
 
@@ -432,29 +426,23 @@ public abstract class BaseClientSubmitter<T>
             throw;
           }
 
-          switch (e)
+          var innerException = e is AggregateException
+                                    {
+                                      InnerExceptions.Count: 1,
+                                    } agg
+                                 ? agg.InnerException
+                                 : e;
+
+          switch (innerException)
           {
-            case AggregateException
-                 {
-                   InnerException: RpcException,
-                 } ex:
-              Logger.LogWarning(ex.InnerException,
-                                "Failure to submit");
-              break;
-            case AggregateException
-                 {
-                   InnerException: IOException,
-                 } ex:
-              Logger.LogWarning(ex.InnerException,
-                                "IOException : Failure to submit, Retrying");
-              break;
-            case IOException ex:
-              Logger.LogWarning(ex,
-                                "IOException Failure to submit");
+            case RpcException:
+            case IOException:
+              Logger.LogWarning(innerException,
+                                "Failure to submit : Retrying");
               break;
             default:
-              Logger.LogError(e,
-                              "Unknown failure :");
+              Logger.LogError(innerException,
+                              "Unknown failure");
               throw;
           }
 

--- a/Client/src/Common/Submitter/BaseClientSubmitter.cs
+++ b/Client/src/Common/Submitter/BaseClientSubmitter.cs
@@ -398,6 +398,11 @@ public abstract class BaseClientSubmitter<T>
 
     foreach (var taskChunk in tasks.ToChunks(100))
     {
+      if (taskChunk.Length == 0)
+      {
+        continue;
+      }
+
       for (var nbRetry = 0; nbRetry < maxRetries; nbRetry++)
       {
         using var channel     = ChannelPool.GetChannel();

--- a/Tests/ArmoniK.EndToEndTests/ArmoniK.EndToEndTests.Common/ArmoniK.EndToEndTests.Common.csproj
+++ b/Tests/ArmoniK.EndToEndTests/ArmoniK.EndToEndTests.Common/ArmoniK.EndToEndTests.Common.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ArmoniK.Api.Common" Version="3.14.0" />
+    <PackageReference Include="ArmoniK.Api.Common" Version="3.15.0-edge.23.b178614" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />

--- a/Worker/src/Common/ArmoniK.DevelopmentKit.Worker.Common.csproj
+++ b/Worker/src/Common/ArmoniK.DevelopmentKit.Worker.Common.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ArmoniK.Api.Worker" Version="3.14.0" />
+    <PackageReference Include="ArmoniK.Api.Worker" Version="3.15.0-edge.23.b178614" />
     <PackageReference Include="AWSSDK.S3" Version="3.7.106.1" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.18.1" />


### PR DESCRIPTION
This is a first draft for removing the submitter service from the method chunkSubmitWithDependencies. It is the same implementation used in [ArmoniK.Core](https://github.com/aneoconsulting/ArmoniK.Core/blob/main/Tests/HtcMock/Client/src/SessionClient.cs). What is missed in this draft is to label the payloads. 
Another more relevant improvements are possible: submit tasks in a batch not one by one