### PR TITLE
chore: Use core version specified in armonik

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -291,7 +291,6 @@ jobs:
           working-directory: ${{ github.workspace }}/infra
           type: localhost
           ext-csharp-version: ${{ needs.versionning.outputs.version }}
-          core-version: 0.24.2
           shared-data-folder: ${{ env.ARMONIK_SHARED_HOST_PATH }}
           log-suffix: container
 


### PR DESCRIPTION
Use core version specified in armonik.

This will match the infra version for tests .
This will allow to test in pipeline with latest version in armoniK repository.