### PR TITLE
chore(renovate): enable semantic commits in renovate conf

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,9 @@
     ":semanticCommitTypeAll(chore)",
     "helpers:pinGitHubActionDigests"
   ],
+  "semanticCommits": "enabled",
   "rangeStrategy": "bump",
+  "prBodyTemplate": "# Motivation\n\nAutomated dependency update by Renovate bot.\n\n# Description\n\n{{{table}}}{{{notes}}}\n\n# Testing\n\nThis is an automated dependency update. No functional changes are expected.\n\n# Impact\n\n{{{changelogs}}}\n\n# Additional Information\n\n{{{warnings}}}{{{errors}}}{{{controls}}}This PR was generated automatically by [Renovate](https://docs.renovatebot.com/).",
   "packageRules": [
     {
       "groupName": "npm packages",


### PR DESCRIPTION
Renovate-generated PRs were failing CI because the PR title linter (amannn/action-semantic-pull-request) could not guarantee a conventional commits format when semanticCommits was left on "auto".